### PR TITLE
Work from post-MOC technical debt resolution project branch

### DIFF
--- a/.github/workflows/project-pull-request.yml
+++ b/.github/workflows/project-pull-request.yml
@@ -1,0 +1,184 @@
+name: Pull request builder for project branch
+
+run-name: Pull request for ${{ github.head_ref }} to ${{ github.base_ref }} by ${{ github.actor }}
+
+env:
+  LINT_FLAGS: -W clippy::all -W clippy::pedantic -W clippy::cargo
+  RUST_TOOLCHAIN: 'nightly-2024-07-21'
+  LLVM_VERSION: 18
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - 'project/*'
+
+permissions: {}
+
+jobs:
+  format:
+    name: Format check
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Setup toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+          components: rustfmt
+
+      - name: Install GSSAPI development packages
+        uses: ConorMacBride/install-package@v1
+        with:
+          apt: libkrb5-dev
+
+      - name: Check formatting
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check --verbose
+
+  check:
+    name: Compile warnings
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Setup toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+
+      - name: Install GSSAPI development packages
+        uses: ConorMacBride/install-package@v1
+        with:
+          apt: libkrb5-dev
+
+      - name: Check for compile warnings
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  lint:
+    name: Lint check
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Setup toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+          components: clippy
+
+      - name: Install GSSAPI development packages
+        uses: ConorMacBride/install-package@v1
+        with:
+          apt: libkrb5-dev
+
+      - name: Lint check
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: -- ${{ env.LINT_PARAMS }}
+
+  license:
+    name: License header check
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Check license header
+        uses: apache/skywalking-eyes/header@main
+
+  dep-branches:
+    name: Constellation dependency branch check
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Check branches for constellation dependencies
+        run: |
+          if `cargo tree | grep github.com/constellation-system | sed  's/[^?]*?//' | sed 's/#.*//' | sed 's/branch=//' | sed "s:%2[fF]:/:" | grep -Evq "^${{ github.base_ref }}$"`; then
+            echo "Constellation depnedencies not on ${{ github.base_ref }} branch:"
+            cargo tree | grep github.com/constellation-system
+            exit 1
+          fi

--- a/.github/workflows/project-push.yml
+++ b/.github/workflows/project-push.yml
@@ -1,0 +1,183 @@
+name: Project branch builder
+
+run-name: Push to ${{ github.ref_name }} by ${{ github.actor }}
+
+env:
+  LINT_FLAGS: -W clippy::all -W clippy::pedantic -W clippy::cargo
+  RUST_TOOLCHAIN: 'nightly-2024-07-21'
+  LLVM_VERSION: 18
+
+on:
+  push:
+    branches:
+      - 'project/*'
+
+permissions: {}
+
+jobs:
+  format:
+    name: Format check
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Setup toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+          components: rustfmt
+
+      - name: Install GSSAPI development packages
+        uses: ConorMacBride/install-package@v1
+        with:
+          apt: libkrb5-dev
+
+      - name: Check formatting
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check --verbose
+
+  check:
+    name: Compile warnings
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Setup toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+
+      - name: Install GSSAPI development packages
+        uses: ConorMacBride/install-package@v1
+        with:
+          apt: libkrb5-dev
+
+      - name: Check for compile warnings
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  lint:
+    name: Lint check
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Setup toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          override: true
+          components: clippy
+
+      - name: Install GSSAPI development packages
+        uses: ConorMacBride/install-package@v1
+        with:
+          apt: libkrb5-dev
+
+      - name: Lint check
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: -- ${{ env.LINT_PARAMS }}
+
+  license:
+    name: License header check
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Check license header
+        uses: apache/skywalking-eyes/header@main
+
+  dep-branches:
+    name: Constellation dependency branch check
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Cache
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-rust-crates
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - name: Check branches for constellation dependencies
+        run: |
+          if `cargo tree | grep github.com/constellation-system | sed  's/[^?]*?//' | sed 's/#.*//' | sed 's/branch=//' | sed "s:%2[fF]:/:" | grep -Evq "^${{ github.ref_name }}$"`; then
+            echo "Constellation depnedencies not on ${{ github.ref_name }} branch:"
+            cargo tree | grep github.com/constellation-system
+            exit 1
+          fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,8 +58,8 @@ unix = [
 [dependencies]
 asn1rs = { version = "0.3" }
 bitvec = { version = "1.0" }
-constellation-auth = { git = "https://github.com/constellation-system/constellation-auth.git", branch = "devel", default-features = false }
-constellation-common = { git = "https://github.com/constellation-system/constellation-common.git", branch = "devel", default-features = false }
+constellation-auth = { git = "https://github.com/constellation-system/constellation-auth.git", branch = "project/tech-debt", default-features = false }
+constellation-common = { git = "https://github.com/constellation-system/constellation-common.git", branch = "project/tech-debt", default-features = false }
 log = { version = "0.4", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,8 +58,8 @@ unix = [
 [dependencies]
 asn1rs = { version = "0.3" }
 bitvec = { version = "1.0" }
-constellation-auth = { git = "https://github.com/constellation-system/constellation-auth.git", branch = "project/tech-debt", default-features = false }
-constellation-common = { git = "https://github.com/constellation-system/constellation-common.git", branch = "project/tech-debt", default-features = false }
+constellation-auth = { git = "https://github.com/constellation-system/constellation-auth.git", branch = "devel", default-features = false }
+constellation-common = { git = "https://github.com/constellation-system/constellation-common.git", branch = "devel", default-features = false }
 log = { version = "0.4", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 

--- a/src/channels.rs
+++ b/src/channels.rs
@@ -43,6 +43,7 @@ use constellation_common::error::ScopedError;
 use constellation_common::net::IPEndpointAddr;
 use constellation_common::retry::RetryResult;
 use constellation_common::retry::RetryWhen;
+use constellation_common::shutdown::ShutdownFlag;
 use log::error;
 
 use crate::error::BatchError;
@@ -164,6 +165,7 @@ pub trait ChannelsCreate<Ctx, Srcs>: Sized + Channels<Ctx> {
     /// Create an instance of this `Channels`.
     fn create(
         ctx: &mut Ctx,
+        shutdown: ShutdownFlag,
         reporter: Self::Reporter,
         config: Self::Config,
         srcs: Srcs

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -48,7 +48,6 @@ use crate::stream::PushStreamAdd;
 use crate::stream::PushStreamPartyID;
 use crate::stream::PushStreamPrivate;
 use crate::stream::PushStreamPrivateSingle;
-use crate::stream::PushStreamReportError;
 
 /// Private unicast stream built from a [Read]/[Write] instance and a
 /// [DatagramCodec].
@@ -287,24 +286,6 @@ where
         &mut self,
         _batch: &Self::BatchID
     ) -> Result<(), Self::ReportError> {
-        Ok(())
-    }
-}
-
-impl<Msg, Stream, Codec> PushStreamReportError<Infallible>
-    for DatagramCodecStream<Msg, Stream, Codec>
-where
-    Codec: DatagramCodec<Msg> + Send
-{
-    type ReportError = Infallible;
-
-    fn report_error(
-        &mut self,
-        _error: &Infallible
-    ) -> Result<(), Self::ReportError> {
-        error!(target: "datagram-codec-stream",
-               "should never call report_error");
-
         Ok(())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -77,27 +77,6 @@ pub enum CompoundBatchError<Idx, Success, Err> {
     }
 }
 
-// ISSUE #6: this actually isn't used everywhere it probably should be.
-
-/// A convenience type for implementing instances of
-/// [push](crate::stream::PushStreamSingle::push).
-///
-/// Frequently, `push` will be implemented simply by creating a new
-/// batch, adding the one message, and then pushing the batch.  This
-/// type can serve as the error returned from such an implementation.
-pub enum PushError<Batch, Parties, Add, Finish, Other> {
-    /// Error occurred creating the batch.
-    Batch { err: Batch },
-    /// Error occurred adding messages to the batch.
-    Parties { err: Parties },
-    /// Error occurred adding messages to the batch.
-    Add { err: Add },
-    /// Error occurred finishing the batch.
-    Finish { err: Finish },
-    /// Other errors that can occur.
-    Other { err: Other }
-}
-
 /// A collection of both errors and successes that happened when
 /// performing a batch operation.
 ///

--- a/src/multicast.rs
+++ b/src/multicast.rs
@@ -87,8 +87,7 @@ pub struct StreamMulticasterSelections<Inner> {
 ///
 /// This combinator maintains a separate stream for each of a set of
 /// counterparties, and replicates batching commands on each of these
-/// streams.  It also allows for the recipients for each batch to be
-/// controlled through the [PushStreamAddParty] interface.
+/// streams.
 ///
 /// In its most simple use case, this can be used to implement
 /// synthetic multicasting functionality on top of unicast streams.
@@ -661,31 +660,6 @@ where
                 }
             }
             None => Err(CompoundBatchError::BadID { id: *batch })
-        }
-    }
-}
-
-impl<Party, Idx, Msg, Stream, Ctx, Success, Err>
-    PushStreamReportError<CompoundBatchError<Idx, Success, Err>>
-    for StreamMulticaster<Party, Idx, Msg, Stream, Ctx>
-where
-    Idx: Clone + Display + Eq + Hash + From<usize> + Into<usize> + Ord,
-    Stream::BatchID: Clone,
-    Party: Clone + Display + Eq + Hash,
-    Stream: PushStreamAdd<Msg, Ctx> + PushStreamReportError<Err>,
-    Err: Display
-{
-    type ReportError =
-        ErrorSet<Idx, (), <Stream as PushStreamReportError<Err>>::ReportError>;
-
-    fn report_error(
-        &mut self,
-        errors: &CompoundBatchError<Idx, Success, Err>
-    ) -> Result<(), Self::ReportError> {
-        if let CompoundBatchError::Batch { errs } = errors {
-            self.report_error(errs)
-        } else {
-            Ok(())
         }
     }
 }

--- a/src/select/mod.rs
+++ b/src/select/mod.rs
@@ -78,7 +78,6 @@ use crate::stream::PushStreamAdd;
 use crate::stream::PushStreamPartyID;
 use crate::stream::PushStreamPrivate;
 use crate::stream::PushStreamPrivateSingle;
-use crate::stream::PushStreamReportBatchError;
 use crate::stream::PushStreamReportError;
 use crate::stream::PushStreamReporter;
 use crate::stream::PushStreamShared;
@@ -178,7 +177,7 @@ pub struct StreamSelectorBatch<Epoch, BatchID> {
 /// # Stream Abstractions
 ///
 /// This type also implements the [PushStream], [PushStreamAdd],
-/// [PushStreamSingle], and [PushStreamSharedSingle] traits, allowing
+/// [PushStreamPrivate], and [PushStreamShared] traits, allowing
 /// it to function as an abstract stream in and of itself.  When used
 /// in this manner, the scheduler is used to select from one of the
 /// possible streams to create a batch.  All subsequent batch
@@ -2000,33 +1999,6 @@ where
         } else {
             Ok(())
         }
-    }
-}
-
-impl<Epochs, Src, Resolve, Ctx, Error>
-    PushStreamReportBatchError<Error, <Self as PushStream<Ctx>>::BatchID>
-    for StreamSelector<Epochs, Src, Resolve, Ctx>
-where
-    Epochs: Iterator,
-    Epochs::Item: Clone + Display + Eq,
-    Src: ChannelsCreate<Ctx, Vec<String>>,
-    Src::Config: Default,
-    Src::Reporter: Clone,
-    Resolve: Addrs<Addr = Src::Addr>,
-    Resolve::Origin: Clone + Eq + Hash + Into<Option<IPEndpointAddr>>,
-    Src::Stream: Clone + PushStream<Ctx> + Send
-{
-    type ReportBatchError = <Self as PushStream<Ctx>>::ReportError;
-
-    fn report_error_with_batch(
-        &mut self,
-        batch: &StreamSelectorBatch<
-            Epochs::Item,
-            <Src::Stream as PushStream<Ctx>>::BatchID
-        >,
-        _error: &Error
-    ) -> Result<(), Self::ReportBatchError> {
-        self.report_failure(batch)
     }
 }
 

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -46,69 +46,6 @@ use crate::error::ErrorReportInfo;
 pub mod pull;
 pub mod push;
 
-/// Trait for caches used in stream creation to allow shared streams.
-///
-/// This is a trait for types of caches that are used in the
-/// (start_batch)[PushStream::start_batch] process.  This is primarily
-/// used with shared streams, to ensure that only one batch is created
-/// for any given shared stream.
-pub trait StreamBatches {
-    /// ID for batches.
-    type BatchID: Clone;
-    /// ID for streams.
-    type StreamID: Clone;
-
-    /// Create an empty instance.
-    fn new() -> Self;
-
-    /// Create an empty instance with a size hint.
-    fn with_capacity(size: usize) -> Self;
-
-    /// Get the batch corresponding to the `stream`.
-    fn batch(
-        &self,
-        stream: &Self::StreamID
-    ) -> Option<Self::BatchID>;
-
-    /// Add `batch` as the batch ID corresponding to `stream`.
-    fn add_batch(
-        &mut self,
-        stream: Self::StreamID,
-        batch: Self::BatchID
-    );
-}
-
-/// Trait for flags used to manage adding messages to shared streams.
-///
-/// This is a trait for types of flags that are used in the
-/// [add](PushStreamAdd::add),
-/// [finish_batch](PushStream::finish_batch), and
-/// [cancel_batch](PushStream::cancel_batch) process.  This is
-/// primarily used with shared streams, to ensure that only one batch
-/// is created for any given shared stream.
-pub trait StreamFlags {
-    /// Type of stream IDs.
-    type StreamID: Clone;
-
-    /// Create an empty instance.
-    fn new() -> Self;
-
-    /// Create an empty instance with a size hint.
-    fn with_capacity(size: usize) -> Self;
-
-    /// Check if the flag is set for the given stream.
-    fn is_set(
-        &self,
-        stream: &Self::StreamID
-    ) -> bool;
-
-    /// Set the flag for the given stream.
-    fn set(
-        &mut self,
-        stream: Self::StreamID
-    );
-}
-
 // This is a workaround for an OpenSSL implementation issue.
 
 pub trait ConcurrentStream {
@@ -204,13 +141,6 @@ pub trait PullStreamListener<T> {
 pub trait PushStream<Ctx> {
     /// ID for batches.
     type BatchID: Clone;
-
-    /// Type of [StreamBatches] used in [start_batch](PushStream::start_batch).
-    type StartBatchStreamBatches: StreamBatches;
-    /// Type of errors that can occur when creating a new batch.
-    type StartBatchError: BatchError;
-    /// Type of information given by a [RetryResult] for creating a new batch.
-    type StartBatchRetry: RetryWhen + Clone;
     /// Type of errors that can occur when canceling a batch.
     type CancelBatchError: BatchError;
     /// Type of information given by a [RetryResult] for canceling a new batch.
@@ -219,107 +149,21 @@ pub trait PushStream<Ctx> {
     type FinishBatchError: BatchError;
     /// Type of information given by a [RetryResult] for finishing a new batch.
     type FinishBatchRetry: RetryWhen + Clone;
-    /// Type of information given by a [RetryResult] for aborting a
-    /// batch creation.
-    type AbortBatchRetry: RetryWhen + Clone;
-    /// Type of [StreamFlags] used in [add](PushStreamAdd::add).
-    type StreamFlags: StreamFlags;
+    /// Type of stream flags used in [add](PushStreamAdd::add).
+    type StreamFlags: Default;
     /// Type of error that can occur when reporting failures.
     type ReportError: Display;
 
     /// Create an empty
     /// [StreamFlags](PushStream::StreamFlags).
+    #[inline]
     fn empty_flags(&self) -> Self::StreamFlags {
-        Self::StreamFlags::new()
+        Self::StreamFlags::default()
     }
 
     /// Create an empty
-    /// [StartBatchStreamBatches](PushStream::StartBatchStreamBatches).
-    fn empty_batches(&self) -> Self::StartBatchStreamBatches {
-        Self::StartBatchStreamBatches::new()
-    }
-
-    /// Start a new batch.
-    ///
-    /// This creates a new batch, referenced by a
-    /// [BatchID](PushStream::BatchID), to which messages can be added
-    /// using functionality in [PushStreamAdd].
-    ///
-    /// Depending on the implementation, this may allocate resources
-    /// on the underlying stream that will need to be freed using
-    /// [finish_batch](PushStream::finish_batch) or
-    /// [cancel_batch](PushStream::cancel_batch).
-    ///
-    /// The [StreamBatches] implementation `batches` will be used to
-    /// ensure that shared streams have only one batch created for
-    /// them.
-    fn start_batch(
-        &mut self,
-        ctx: &mut Ctx,
-        batches: &mut Self::StartBatchStreamBatches
-    ) -> Result<
-        RetryResult<Self::BatchID, Self::StartBatchRetry>,
-        Self::StartBatchError
-    >;
-
-    /// Retry a previous call to [start_batch](PushStream::start_batch).
-    ///
-    /// This allows a call to `start_batch` that had returned a
-    /// [Retry](RetryResult::Retry) to be retried in an
-    /// implementation-agnostic manner.
-    fn retry_start_batch(
-        &mut self,
-        ctx: &mut Ctx,
-        batches: &mut Self::StartBatchStreamBatches,
-        retry: Self::StartBatchRetry
-    ) -> Result<
-        RetryResult<Self::BatchID, Self::StartBatchRetry>,
-        Self::StartBatchError
-    >;
-
-    /// Retry a previously-failed call to
-    /// [start_batch](PushStream::start_batch).
-    ///
-    /// This allows a call to `start_batch` that had returned a
-    /// recoverable error to be retried in an implementation-agnostic
-    /// manner.
-    fn complete_start_batch(
-        &mut self,
-        ctx: &mut Ctx,
-        batches: &mut Self::StartBatchStreamBatches,
-        err: <Self::StartBatchError as BatchError>::Completable
-    ) -> Result<
-        RetryResult<Self::BatchID, Self::StartBatchRetry>,
-        Self::StartBatchError
-    >;
-
-    /// Abort a previously-failed call to
-    /// [start_batch](PushStream::start_batch).
-    ///
-    /// This will release any resources that were allocated in the
-    /// call to [start_batch](PushStream::start_batch).
-    ///
-    /// In order to avoid an endless cycle, this represents a
-    /// "best-effort", and will not return an error.
-    fn abort_start_batch(
-        &mut self,
-        ctx: &mut Ctx,
-        flags: &mut Self::StreamFlags,
-        err: <Self::StartBatchError as BatchError>::Permanent
-    ) -> RetryResult<(), Self::AbortBatchRetry>;
-
-    /// Retry a previous call to
-    /// [abort_start_batch](PushStream::abort_start_batch).
-    ///
-    /// This allows a call to `abort_start_batch` that had returned a
-    /// [Retry](RetryResult::Retry) to be retried in an
-    /// implementation-agnostic manner.
-    fn retry_abort_start_batch(
-        &mut self,
-        ctx: &mut Ctx,
-        flags: &mut Self::StreamFlags,
-        retry: Self::AbortBatchRetry
-    ) -> RetryResult<(), Self::AbortBatchRetry>;
+    /// [StreamFlags](PushStream::StreamFlags).
+    fn empty_flags_with_capacity(size: usize) -> Self::StreamFlags;
 
     /// Finish a batch, and guarantee that all of its messages have
     /// been sent.
@@ -522,14 +366,6 @@ pub trait PushStreamAdd<T, Ctx>: PushStream<Ctx> {
     ) -> Result<RetryResult<(), Self::AddRetry>, Self::AddError>;
 }
 
-/// Common super-trait for all shared (multi-party) streams.
-pub trait PushStreamShared {
-    /// Type of party IDs.
-    ///
-    /// This should typically be a wrapper around a dense integer value.
-    type PartyID: Clone + Eq + Hash + Ord;
-}
-
 /// Trait for obtaining a reporter for new [PushStream]s.
 pub trait PushStreamReporter<Inner: StreamReporter> {
     /// Type of [StreamReporter] instance provided by
@@ -546,9 +382,17 @@ pub trait PushStreamReporter<Inner: StreamReporter> {
     ) -> Self::Reporter;
 }
 
+pub trait PushStreamPartyID {
+    /// Type of party IDs.
+    ///
+    /// This should typically be a wrapper around a dense integer value.
+    type PartyID: Clone + Eq + Hash + Ord;
+}
+
 /// Trait for obtaining the list of parties associated with a
 /// [PushStreamShared] instance.
-pub trait PushStreamParties: PushStreamShared {
+pub trait PushStreamParties: PushStreamPartyID {
+    /// Iterator for parties.
     type PartiesIter: Iterator<Item = (Self::PartyID, Self::PartyInfo)>;
     /// Detailed information about a party.
     type PartyInfo;
@@ -559,81 +403,427 @@ pub trait PushStreamParties: PushStreamShared {
     fn parties(&self) -> Result<Self::PartiesIter, Self::PartiesError>;
 }
 
-/// Interface for [PushStream]s that support the notion of multiple
-/// possible recipient parties.
-///
-/// The most direct use for this trait is for `PushStream` instances
-/// that represent a multicast-style channel, where messages can be
-/// sent to a collection of possible recipients.
-///
-/// # Atomicity
-///
-/// `PushStream` and its sub-traits *do not* in general guarantee
-/// atomic semantics regarding the sending of messages.  As these
-/// traits represent an abstraction for low-level communications, it
-/// is not generally possible to make such a guarantee.  As such, this
-/// interface *does not* make guarantees about the existence of a
-/// single, discrete point in time where the transmission of messages
-/// along some underlying channel can be said to occur (i.e. a
-/// linearization point).
-///
-/// The actual transmission of messages along the underlying channel
-/// can happen at *any point* after the message is added to the batch.
-/// Because the functionality in this trait affects the recipients, it
-/// is generally necessary to ensure that all recipients are added to
-/// the batch *before* any messages are added.  Failure to do this may
-/// result in some messages not being sent to all the parties that are
-/// indicated.
-pub trait PushStreamAddParty<Ctx>: PushStream<Ctx> + PushStreamShared {
-    /// Type of errors that can occur when adding a recipient party to
-    /// a batch.
-    type AddPartiesError: BatchError;
-    /// Type of information given by a [RetryResult] for adding a
-    /// recipient party to a batch.
-    type AddPartiesRetry: RetryWhen + Clone;
-    /// Iterator for parties.
+pub trait PushStreamShared<Ctx>: PushStream<Ctx> + PushStreamPartyID {
+    /// Type of errors that can occur when selecting streams for a new
+    /// batch.
+    type SelectError: BatchError;
+    /// Type of information given by a [RetryResult] for selecting
+    /// streams for a new batch.
+    type SelectRetry: RetryWhen + Clone;
+    /// Type of errors that can occur when creating a new batch.
+    type CreateBatchError: BatchError;
+    /// Type of information given by a [RetryResult] for creating a new batch.
+    type CreateBatchRetry: RetryWhen + Clone;
+    /// Type of errors that can occur when creating a new batch.
+    type StartBatchError: BatchError;
+    /// Type of information given by a [RetryResult] for creating a new batch.
+    type StartBatchRetry: RetryWhen + Clone;
+    /// Type of information given by a [RetryResult] for aborting a
+    /// batch creation.
+    type AbortBatchRetry: RetryWhen + Clone;
+    /// Type of selection cache used in [select](PushStream::select).
+    type Selections: Clone + Default;
+    /// Type of batch cache used in [start_batch](PushStream::start_batch).
+    type StartBatchStreamBatches: Clone + Default;
 
-    /// Add recipient parties to a batch.
+    /// Create an empty
+    /// [Selections](PushStreamShared::Selections).
+    #[inline]
+    fn empty_selections(&self) -> Self::Selections {
+        Self::Selections::default()
+    }
+
+    /// Create an empty
+    /// [Selections](PushStreamShared::Selections).
+    fn empty_selections_with_capacity(size: usize) -> Self::Selections;
+
+    /// Create an empty
+    /// [StartBatchStreamBatches](PushStreamShared::StartBatchStreamBatches).
+    #[inline]
+    fn empty_batches(&self) -> Self::StartBatchStreamBatches {
+        Self::StartBatchStreamBatches::default()
+    }
+
+    /// Create an empty
+    /// [StartBatchStreamBatches](PushStreamShared::StartBatchStreamBatches).
+    fn empty_batches_with_capacity(
+        size: usize
+    ) -> Self::StartBatchStreamBatches;
+
+    /// Select streams for a new batch.
     ///
-    /// This will cause messages added to this batch using
-    /// [add](PushStreamAdd::add) to be sent to `parties`.  This is
-    /// guaranteed for any calls to `add` that happen *after* this
-    /// call on the same batch; no general guarantees are made
-    /// regarding calls to `add` that occur *before* this call
-    /// however.
-    fn add_parties<I>(
+    /// This will do any stream selection, and will record decisions
+    /// in `batches`.
+    fn select<'a, I>(
         &mut self,
         ctx: &mut Ctx,
-        parties: I,
-        batch: &Self::BatchID
-    ) -> Result<RetryResult<(), Self::AddPartiesRetry>, Self::AddPartiesError>
+        selections: &mut Self::Selections,
+        parties: I
+    ) -> Result<RetryResult<(), Self::SelectRetry>, Self::SelectError>
     where
-        I: Iterator<Item = Self::PartyID>;
+        I: Iterator<Item = &'a Self::PartyID>,
+        Self::PartyID: 'a;
 
-    /// Retry a previous call to [add](PushStreamAddParty::add_parties).
+    /// Retry a previous call to [start_batch](PushStream::start_batch).
     ///
-    /// This allows a call to `add_parties` that had returned a
+    /// This allows a call to `start_batch` that had returned a
     /// [Retry](RetryResult::Retry) to be retried in an
     /// implementation-agnostic manner.
-    fn retry_add_parties(
+    fn retry_select(
         &mut self,
         ctx: &mut Ctx,
-        batch: &Self::BatchID,
-        retry: Self::AddPartiesRetry
-    ) -> Result<RetryResult<(), Self::AddPartiesRetry>, Self::AddPartiesError>;
+        selections: &mut Self::Selections,
+        retry: Self::SelectRetry
+    ) -> Result<RetryResult<(), Self::SelectRetry>, Self::SelectError>;
 
     /// Retry a previously-failed call to
-    /// [add](PushStreamAddParty::add_parties).
+    /// [select](PushStream::select).
     ///
-    /// This allows a call to `add_parties` that had returned a
-    /// recoverable error to be retried in an implementation-agnostic
-    /// manner.
-    fn complete_add_parties(
+    /// This allows a call to `select` that had returned a recoverable
+    /// error to be retried in an implementation-agnostic manner.
+    fn complete_select(
         &mut self,
         ctx: &mut Ctx,
-        batch: &Self::BatchID,
-        err: <Self::AddPartiesError as BatchError>::Completable
-    ) -> Result<RetryResult<(), Self::AddPartiesRetry>, Self::AddPartiesError>;
+        selections: &mut Self::Selections,
+        err: <Self::SelectError as BatchError>::Completable
+    ) -> Result<RetryResult<(), Self::SelectRetry>, Self::SelectError>;
+
+    /// Create a new batch.
+    ///
+    /// This creates a new batch, referenced by a
+    /// [BatchID](PushStream::BatchID).  This is not meant to be used
+    /// directly; [start_batch](PushStream::start_batch) should be
+    /// used instead.
+    fn create_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        batches: &mut Self::StartBatchStreamBatches,
+        selections: &Self::Selections
+    ) -> Result<
+        RetryResult<Self::BatchID, Self::CreateBatchRetry>,
+        Self::CreateBatchError
+    >;
+
+    /// Retry a previous call to [create_batch](PushStream::create_batch).
+    ///
+    /// This allows a call to `create_batch` that had returned a
+    /// [Retry](RetryResult::Retry) to be retried in an
+    /// implementation-agnostic manner.
+    fn retry_create_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        batches: &mut Self::StartBatchStreamBatches,
+        selections: &Self::Selections,
+        retry: Self::CreateBatchRetry
+    ) -> Result<
+        RetryResult<Self::BatchID, Self::CreateBatchRetry>,
+        Self::CreateBatchError
+    >;
+
+    /// Retry a previously-failed call to
+    /// [create_batch](PushStream::create_batch).
+    ///
+    /// This allows a call to `create_batch` that had returned a
+    /// recoverable error to be retried in an implementation-agnostic
+    /// manner.
+    fn complete_create_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        batches: &mut Self::StartBatchStreamBatches,
+        selections: &Self::Selections,
+        err: <Self::CreateBatchError as BatchError>::Completable
+    ) -> Result<
+        RetryResult<Self::BatchID, Self::CreateBatchRetry>,
+        Self::CreateBatchError
+    >;
+
+    /// Start a new batch.
+    ///
+    /// This creates a new batch, referenced by a
+    /// [BatchID](PushStream::BatchID), to which messages can be added
+    /// using functionality in [PushStreamAdd].
+    ///
+    /// Depending on the implementation, this may allocate resources
+    /// on the underlying stream that will need to be freed using
+    /// [finish_batch](PushStream::finish_batch) or
+    /// [cancel_batch](PushStream::cancel_batch).
+    fn start_batch<'a, I>(
+        &mut self,
+        ctx: &mut Ctx,
+        parties: I
+    ) -> Result<
+        RetryResult<Self::BatchID, Self::StartBatchRetry>,
+        Self::StartBatchError
+    >
+    where
+        I: Iterator<Item = &'a Self::PartyID>,
+        Self::PartyID: 'a;
+
+    /// Retry a previous call to [start_batch](PushStream::start_batch).
+    ///
+    /// This allows a call to `start_batch` that had returned a
+    /// [Retry](RetryResult::Retry) to be retried in an
+    /// implementation-agnostic manner.
+    fn retry_start_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        retry: Self::StartBatchRetry
+    ) -> Result<
+        RetryResult<Self::BatchID, Self::StartBatchRetry>,
+        Self::StartBatchError
+    >;
+
+    /// Retry a previously-failed call to
+    /// [start_batch](PushStream::start_batch).
+    ///
+    /// This allows a call to `start_batch` that had returned a
+    /// recoverable error to be retried in an implementation-agnostic
+    /// manner.
+    fn complete_start_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        err: <Self::StartBatchError as BatchError>::Completable
+    ) -> Result<
+        RetryResult<Self::BatchID, Self::StartBatchRetry>,
+        Self::StartBatchError
+    >;
+
+    /// Abort a previously-failed call to
+    /// [start_batch](PushStream::start_batch).
+    ///
+    /// This will release any resources that were allocated in the
+    /// call to [start_batch](PushStream::start_batch).
+    ///
+    /// In order to avoid an endless cycle, this represents a
+    /// "best-effort", and will not return an error.
+    fn abort_start_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        flags: &mut Self::StreamFlags,
+        err: <Self::StartBatchError as BatchError>::Permanent
+    ) -> RetryResult<(), Self::AbortBatchRetry>;
+
+    /// Retry a previous call to
+    /// [abort_start_batch](PushStream::abort_start_batch).
+    ///
+    /// This allows a call to `abort_start_batch` that had returned a
+    /// [Retry](RetryResult::Retry) to be retried in an
+    /// implementation-agnostic manner.
+    fn retry_abort_start_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        flags: &mut Self::StreamFlags,
+        retry: Self::AbortBatchRetry
+    ) -> RetryResult<(), Self::AbortBatchRetry>;
+}
+
+pub trait PushStreamPrivate<Ctx>: PushStream<Ctx> {
+    /// Type of errors that can occur when selecting streams for a new
+    /// batch.
+    type SelectError: BatchError;
+    /// Type of information given by a [RetryResult] for selecting
+    /// streams for a new batch.
+    type SelectRetry: RetryWhen + Clone;
+    /// Type of errors that can occur when creating a new batch.
+    type CreateBatchError: BatchError;
+    /// Type of information given by a [RetryResult] for creating a new batch.
+    type CreateBatchRetry: RetryWhen + Clone;
+    /// Type of errors that can occur when starting a new batch.
+    type StartBatchError: BatchError;
+    /// Type of information given by a [RetryResult] for starting a new batch.
+    type StartBatchRetry: RetryWhen + Clone;
+    /// Type of information given by a [RetryResult] for aborting a
+    /// batch creation.
+    type AbortBatchRetry: RetryWhen + Clone;
+    /// Type of selection cache used in [select](PushStream::select).
+    type Selections: Clone + Default;
+    /// Type of batch cache used in [start_batch](PushStream::start_batch).
+    type StartBatchStreamBatches: Clone + Default;
+
+    /// Create an empty
+    /// [Selections](PushStreamPrivate::Selections).
+    #[inline]
+    fn empty_selections(&self) -> Self::Selections {
+        Self::Selections::default()
+    }
+
+    /// Create an empty
+    /// [Selections](PushStreamPrivate::Selections).
+    fn empty_selections_with_capacity(size: usize) -> Self::Selections;
+
+    /// Create an empty
+    /// [StartBatchStreamBatches](PushStreamPrivate::StartBatchStreamBatches).
+    #[inline]
+    fn empty_batches(&self) -> Self::StartBatchStreamBatches {
+        Self::StartBatchStreamBatches::default()
+    }
+
+    /// Create an empty
+    /// [StartBatchStreamBatches](PushStreamPrivate::StartBatchStreamBatches).
+    fn empty_batches_with_capacity(
+        size: usize
+    ) -> Self::StartBatchStreamBatches;
+
+    /// Select streams for a new batch.
+    ///
+    /// This will do any stream selection, and will record decisions
+    /// in `batches`.
+    fn select(
+        &mut self,
+        ctx: &mut Ctx,
+        selections: &mut Self::Selections
+    ) -> Result<RetryResult<(), Self::SelectRetry>, Self::SelectError>;
+    /// Retry a previous call to [start_batch](PushStream::start_batch).
+    ///
+    /// This allows a call to `start_batch` that had returned a
+    /// [Retry](RetryResult::Retry) to be retried in an
+    /// implementation-agnostic manner.
+    fn retry_select(
+        &mut self,
+        ctx: &mut Ctx,
+        selections: &mut Self::Selections,
+        retry: Self::SelectRetry
+    ) -> Result<RetryResult<(), Self::SelectRetry>, Self::SelectError>;
+
+    /// Retry a previously-failed call to
+    /// [select](PushStream::select).
+    ///
+    /// This allows a call to `select` that had returned a recoverable
+    /// error to be retried in an implementation-agnostic manner.
+    fn complete_select(
+        &mut self,
+        ctx: &mut Ctx,
+        selections: &mut Self::Selections,
+        err: <Self::SelectError as BatchError>::Completable
+    ) -> Result<RetryResult<(), Self::SelectRetry>, Self::SelectError>;
+
+    /// Create a new batch.
+    ///
+    /// This creates a new batch, referenced by a
+    /// [BatchID](PushStream::BatchID).  This is not meant to be used
+    /// directly; [start_batch](PushStream::start_batch) should be
+    /// used instead.
+    fn create_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        batches: &mut Self::StartBatchStreamBatches,
+        selections: &Self::Selections
+    ) -> Result<
+        RetryResult<Self::BatchID, Self::CreateBatchRetry>,
+        Self::CreateBatchError
+    >;
+
+    /// Retry a previous call to [create_batch](PushStream::create_batch).
+    ///
+    /// This allows a call to `create_batch` that had returned a
+    /// [Retry](RetryResult::Retry) to be retried in an
+    /// implementation-agnostic manner.
+    fn retry_create_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        batches: &mut Self::StartBatchStreamBatches,
+        selections: &Self::Selections,
+        retry: Self::CreateBatchRetry
+    ) -> Result<
+        RetryResult<Self::BatchID, Self::CreateBatchRetry>,
+        Self::CreateBatchError
+    >;
+
+    /// Retry a previously-failed call to
+    /// [create_batch](PushStream::create_batch).
+    ///
+    /// This allows a call to `create_batch` that had returned a
+    /// recoverable error to be retried in an implementation-agnostic
+    /// manner.
+    fn complete_create_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        batches: &mut Self::StartBatchStreamBatches,
+        selections: &Self::Selections,
+        err: <Self::CreateBatchError as BatchError>::Completable
+    ) -> Result<
+        RetryResult<Self::BatchID, Self::CreateBatchRetry>,
+        Self::CreateBatchError
+    >;
+
+    /// Start a new batch.
+    ///
+    /// This creates a new batch, referenced by a
+    /// [BatchID](PushStream::BatchID), to which messages can be added
+    /// using functionality in [PushStreamAdd].
+    ///
+    /// Depending on the implementation, this may allocate resources
+    /// on the underlying stream that will need to be freed using
+    /// [finish_batch](PushStream::finish_batch) or
+    /// [cancel_batch](PushStream::cancel_batch).
+    ///
+    /// The [StreamBatches] implementation `batches` will be used to
+    /// ensure that shared streams have only one batch created for
+    /// them.
+    fn start_batch(
+        &mut self,
+        ctx: &mut Ctx
+    ) -> Result<
+        RetryResult<Self::BatchID, Self::StartBatchRetry>,
+        Self::StartBatchError
+    >;
+
+    /// Retry a previous call to [start_batch](PushStream::start_batch).
+    ///
+    /// This allows a call to `start_batch` that had returned a
+    /// [Retry](RetryResult::Retry) to be retried in an
+    /// implementation-agnostic manner.
+    fn retry_start_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        retry: Self::StartBatchRetry
+    ) -> Result<
+        RetryResult<Self::BatchID, Self::StartBatchRetry>,
+        Self::StartBatchError
+    >;
+
+    /// Retry a previously-failed call to
+    /// [start_batch](PushStream::start_batch).
+    ///
+    /// This allows a call to `start_batch` that had returned a
+    /// recoverable error to be retried in an implementation-agnostic
+    /// manner.
+    fn complete_start_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        err: <Self::StartBatchError as BatchError>::Completable
+    ) -> Result<
+        RetryResult<Self::BatchID, Self::StartBatchRetry>,
+        Self::StartBatchError
+    >;
+
+    /// Abort a previously-failed call to
+    /// [start_batch](PushStream::start_batch).
+    ///
+    /// This will release any resources that were allocated in the
+    /// call to [start_batch](PushStream::start_batch).
+    ///
+    /// In order to avoid an endless cycle, this represents a
+    /// "best-effort", and will not return an error.
+    fn abort_start_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        flags: &mut Self::StreamFlags,
+        err: <Self::StartBatchError as BatchError>::Permanent
+    ) -> RetryResult<(), Self::AbortBatchRetry>;
+
+    /// Retry a previous call to
+    /// [abort_start_batch](PushStream::abort_start_batch).
+    ///
+    /// This allows a call to `abort_start_batch` that had returned a
+    /// [Retry](RetryResult::Retry) to be retried in an
+    /// implementation-agnostic manner.
+    fn retry_abort_start_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        flags: &mut Self::StreamFlags,
+        retry: Self::AbortBatchRetry
+    ) -> RetryResult<(), Self::AbortBatchRetry>;
 }
 
 /// Helper trait for sending single messages on shared streams.
@@ -645,7 +835,7 @@ pub trait PushStreamAddParty<Ctx>: PushStream<Ctx> + PushStreamShared {
 /// one.  In some cases; however, it may be a more efficient
 /// implementation.
 pub trait PushStreamSharedSingle<T, Ctx>:
-    PushStreamAdd<T, Ctx> + PushStreamAddParty<Ctx> {
+    PushStreamAdd<T, Ctx> + PushStreamShared<Ctx> {
     /// Type of errors that can occur when sending a single message.
     type PushError: BatchError;
     /// Type of information given by a [RetryResult] for sending a
@@ -664,14 +854,15 @@ pub trait PushStreamSharedSingle<T, Ctx>:
     /// single-element batch, and may often be implemented that way.
     /// The batch ID returned is for downstream tracking purposes, and
     /// can be used as the equivalent of a message ID.
-    fn push<I>(
+    fn push<'a, I>(
         &mut self,
         ctx: &mut Ctx,
         parties: I,
         msg: &T
     ) -> Result<RetryResult<Self::BatchID, Self::PushRetry>, Self::PushError>
     where
-        I: Iterator<Item = Self::PartyID>;
+        I: Iterator<Item = &'a Self::PartyID>,
+        Self::PartyID: 'a;
 
     /// Retry a previous call to [push](PushStreamSharedSingle::push).
     ///
@@ -722,7 +913,8 @@ pub trait PushStreamSharedSingle<T, Ctx>:
 /// on a [PushStream].  In many cases, this will be a "derived form",
 /// using the batching functionality to send a batch of size one.  In
 /// some cases; however, it may be a more efficient implementation.
-pub trait PushStreamSingle<T, Ctx>: PushStreamAdd<T, Ctx> {
+pub trait PushStreamPrivateSingle<T, Ctx>:
+    PushStreamAdd<T, Ctx> + PushStreamPrivate<Ctx> {
     /// Type of errors that can occur when sending a single message.
     type PushError: BatchError;
     /// Type of information given by a [RetryResult] for sending a
@@ -817,14 +1009,6 @@ pub struct CompoundBatches<Batch> {
     batches: Vec<Option<Batch>>,
     avail: BitVec,
     config: BatchSlotsConfig
-}
-
-/// Implementation of [StreamBatches] that does not perform caching.
-///
-/// This is intended for use when implementing low-level streams with
-/// private unicast channels, which *should not* cache batch creation.
-pub struct NullBatches<BatchID: Clone> {
-    batch: PhantomData<BatchID>
 }
 
 /// Wrapper around [PushStream] and sub-traits that adds
@@ -1030,114 +1214,17 @@ impl<Ctx, Inner> PushStream<Ctx> for ThreadedStream<Inner>
 where
     Inner: PushStream<Ctx>
 {
-    type AbortBatchRetry = Inner::AbortBatchRetry;
     type BatchID = Inner::BatchID;
     type CancelBatchError = ThreadedStreamError<Inner::CancelBatchError>;
     type CancelBatchRetry = Inner::CancelBatchRetry;
     type FinishBatchError = ThreadedStreamError<Inner::FinishBatchError>;
     type FinishBatchRetry = Inner::FinishBatchRetry;
     type ReportError = ThreadedStreamError<Inner::ReportError>;
-    type StartBatchError = ThreadedStreamError<Inner::StartBatchError>;
-    type StartBatchRetry = Inner::StartBatchRetry;
-    type StartBatchStreamBatches = Inner::StartBatchStreamBatches;
     type StreamFlags = Inner::StreamFlags;
 
-    fn start_batch(
-        &mut self,
-        ctx: &mut Ctx,
-        batches: &mut Self::StartBatchStreamBatches
-    ) -> Result<
-        RetryResult<Self::BatchID, Self::StartBatchRetry>,
-        Self::StartBatchError
-    > {
-        let mut guard = self
-            .inner
-            .lock()
-            .map_err(|_| ThreadedStreamError::MutexPoison)?;
-
-        guard
-            .start_batch(ctx, batches)
-            .map_err(|err| ThreadedStreamError::Inner { error: err })
-    }
-
-    fn retry_start_batch(
-        &mut self,
-        ctx: &mut Ctx,
-        batches: &mut Self::StartBatchStreamBatches,
-        retry: Self::StartBatchRetry
-    ) -> Result<
-        RetryResult<Self::BatchID, Self::StartBatchRetry>,
-        Self::StartBatchError
-    > {
-        let mut guard = self
-            .inner
-            .lock()
-            .map_err(|_| ThreadedStreamError::MutexPoison)?;
-
-        guard
-            .retry_start_batch(ctx, batches, retry)
-            .map_err(|err| ThreadedStreamError::Inner { error: err })
-    }
-
-    fn complete_start_batch(
-        &mut self,
-        ctx: &mut Ctx,
-        batches: &mut Self::StartBatchStreamBatches,
-        err: <Self::StartBatchError as BatchError>::Completable
-    ) -> Result<
-        RetryResult<Self::BatchID, Self::StartBatchRetry>,
-        Self::StartBatchError
-    > {
-        let mut guard = self
-            .inner
-            .lock()
-            .map_err(|_| ThreadedStreamError::MutexPoison)?;
-
-        guard
-            .complete_start_batch(ctx, batches, err)
-            .map_err(|err| ThreadedStreamError::Inner { error: err })
-    }
-
-    fn abort_start_batch(
-        &mut self,
-        ctx: &mut Ctx,
-        flags: &mut Self::StreamFlags,
-        err: <Self::StartBatchError as BatchError>::Permanent
-    ) -> RetryResult<(), Self::AbortBatchRetry> {
-        match err {
-            ThreadedStreamError::Inner { error } => match self.inner.lock() {
-                Ok(mut guard) => guard.abort_start_batch(ctx, flags, error),
-                Err(_) => {
-                    error!(target: "threaded-stream",
-                           "mutex poisoned");
-
-                    RetryResult::Success(())
-                }
-            },
-            ThreadedStreamError::MutexPoison => {
-                warn!(target: "threaded-stream",
-                      "could not cancel batch with error: mutex poisoned");
-
-                RetryResult::Success(())
-            }
-        }
-    }
-
-    fn retry_abort_start_batch(
-        &mut self,
-        ctx: &mut Ctx,
-        flags: &mut Self::StreamFlags,
-        retry: Self::AbortBatchRetry
-    ) -> RetryResult<(), Self::AbortBatchRetry> {
-        match self.inner.lock() {
-            Ok(mut guard) => guard.retry_abort_start_batch(ctx, flags, retry),
-            Err(_) => {
-                error!(target: "threaded-stream",
-                       "mutex poisoned");
-
-                RetryResult::Success(())
-            }
-        }
+    #[inline]
+    fn empty_flags_with_capacity(size: usize) -> Self::StreamFlags {
+        Inner::empty_flags_with_capacity(size)
     }
 
     fn finish_batch(
@@ -1355,9 +1442,9 @@ where
     }
 }
 
-impl<Inner> PushStreamShared for ThreadedStream<Inner>
+impl<Inner> PushStreamPartyID for ThreadedStream<Inner>
 where
-    Inner: PushStreamShared
+    Inner: PushStreamPartyID
 {
     type PartyID = Inner::PartyID;
 }
@@ -1382,63 +1469,467 @@ where
     }
 }
 
-impl<Ctx, Inner> PushStreamAddParty<Ctx> for ThreadedStream<Inner>
+impl<Ctx, Inner> PushStreamPrivate<Ctx> for ThreadedStream<Inner>
 where
-    Inner: PushStreamAddParty<Ctx>
+    Inner: PushStreamPrivate<Ctx>
 {
-    type AddPartiesError = ThreadedStreamError<Inner::AddPartiesError>;
-    type AddPartiesRetry = Inner::AddPartiesRetry;
+    type AbortBatchRetry = Inner::AbortBatchRetry;
+    type CreateBatchError = ThreadedStreamError<Inner::CreateBatchError>;
+    type CreateBatchRetry = Inner::CreateBatchRetry;
+    type SelectError = ThreadedStreamError<Inner::SelectError>;
+    type SelectRetry = Inner::SelectRetry;
+    type Selections = Inner::Selections;
+    type StartBatchError = ThreadedStreamError<Inner::StartBatchError>;
+    type StartBatchRetry = Inner::StartBatchRetry;
+    type StartBatchStreamBatches = Inner::StartBatchStreamBatches;
 
-    fn add_parties<I>(
+    #[inline]
+    fn empty_selections_with_capacity(size: usize) -> Self::Selections {
+        Inner::empty_selections_with_capacity(size)
+    }
+
+    #[inline]
+    fn empty_batches_with_capacity(
+        size: usize
+    ) -> Self::StartBatchStreamBatches {
+        Inner::empty_batches_with_capacity(size)
+    }
+
+    fn select(
         &mut self,
         ctx: &mut Ctx,
-        parties: I,
-        batch: &Self::BatchID
-    ) -> Result<RetryResult<(), Self::AddPartiesRetry>, Self::AddPartiesError>
+        selections: &mut Self::Selections
+    ) -> Result<RetryResult<(), Self::SelectRetry>, Self::SelectError> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| ThreadedStreamError::MutexPoison)?;
+
+        guard
+            .select(ctx, selections)
+            .map_err(|err| ThreadedStreamError::Inner { error: err })
+    }
+
+    fn retry_select(
+        &mut self,
+        ctx: &mut Ctx,
+        selections: &mut Self::Selections,
+        retry: Self::SelectRetry
+    ) -> Result<RetryResult<(), Self::SelectRetry>, Self::SelectError> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| ThreadedStreamError::MutexPoison)?;
+
+        guard
+            .retry_select(ctx, selections, retry)
+            .map_err(|err| ThreadedStreamError::Inner { error: err })
+    }
+
+    fn complete_select(
+        &mut self,
+        ctx: &mut Ctx,
+        selections: &mut Self::Selections,
+        err: <Self::SelectError as BatchError>::Completable
+    ) -> Result<RetryResult<(), Self::SelectRetry>, Self::SelectError> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| ThreadedStreamError::MutexPoison)?;
+
+        guard
+            .complete_select(ctx, selections, err)
+            .map_err(|err| ThreadedStreamError::Inner { error: err })
+    }
+
+    fn create_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        batches: &mut Self::StartBatchStreamBatches,
+        selections: &Self::Selections
+    ) -> Result<
+        RetryResult<Self::BatchID, Self::CreateBatchRetry>,
+        Self::CreateBatchError
+    > {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| ThreadedStreamError::MutexPoison)?;
+
+        guard
+            .create_batch(ctx, batches, selections)
+            .map_err(|err| ThreadedStreamError::Inner { error: err })
+    }
+
+    fn retry_create_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        batches: &mut Self::StartBatchStreamBatches,
+        selections: &Self::Selections,
+        retry: Self::CreateBatchRetry
+    ) -> Result<
+        RetryResult<Self::BatchID, Self::CreateBatchRetry>,
+        Self::CreateBatchError
+    > {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| ThreadedStreamError::MutexPoison)?;
+
+        guard
+            .retry_create_batch(ctx, batches, selections, retry)
+            .map_err(|err| ThreadedStreamError::Inner { error: err })
+    }
+
+    fn complete_create_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        batches: &mut Self::StartBatchStreamBatches,
+        selections: &Self::Selections,
+        err: <Self::CreateBatchError as BatchError>::Completable
+    ) -> Result<
+        RetryResult<Self::BatchID, Self::CreateBatchRetry>,
+        Self::CreateBatchError
+    > {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| ThreadedStreamError::MutexPoison)?;
+
+        guard
+            .complete_create_batch(ctx, batches, selections, err)
+            .map_err(|err| ThreadedStreamError::Inner { error: err })
+    }
+
+    fn start_batch(
+        &mut self,
+        ctx: &mut Ctx
+    ) -> Result<
+        RetryResult<Self::BatchID, Self::StartBatchRetry>,
+        Self::StartBatchError
+    > {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| ThreadedStreamError::MutexPoison)?;
+
+        guard
+            .start_batch(ctx)
+            .map_err(|err| ThreadedStreamError::Inner { error: err })
+    }
+
+    fn retry_start_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        retry: Self::StartBatchRetry
+    ) -> Result<
+        RetryResult<Self::BatchID, Self::StartBatchRetry>,
+        Self::StartBatchError
+    > {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| ThreadedStreamError::MutexPoison)?;
+
+        guard
+            .retry_start_batch(ctx, retry)
+            .map_err(|err| ThreadedStreamError::Inner { error: err })
+    }
+
+    fn complete_start_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        err: <Self::StartBatchError as BatchError>::Completable
+    ) -> Result<
+        RetryResult<Self::BatchID, Self::StartBatchRetry>,
+        Self::StartBatchError
+    > {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| ThreadedStreamError::MutexPoison)?;
+
+        guard
+            .complete_start_batch(ctx, err)
+            .map_err(|err| ThreadedStreamError::Inner { error: err })
+    }
+
+    fn abort_start_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        flags: &mut Self::StreamFlags,
+        err: <Self::StartBatchError as BatchError>::Permanent
+    ) -> RetryResult<(), Self::AbortBatchRetry> {
+        match err {
+            ThreadedStreamError::Inner { error } => match self.inner.lock() {
+                Ok(mut guard) => guard.abort_start_batch(ctx, flags, error),
+                Err(_) => {
+                    error!(target: "threaded-stream",
+                           "mutex poisoned");
+
+                    RetryResult::Success(())
+                }
+            },
+            ThreadedStreamError::MutexPoison => {
+                warn!(target: "threaded-stream",
+                      "could not cancel batch with error: mutex poisoned");
+
+                RetryResult::Success(())
+            }
+        }
+    }
+
+    fn retry_abort_start_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        flags: &mut Self::StreamFlags,
+        retry: Self::AbortBatchRetry
+    ) -> RetryResult<(), Self::AbortBatchRetry> {
+        match self.inner.lock() {
+            Ok(mut guard) => guard.retry_abort_start_batch(ctx, flags, retry),
+            Err(_) => {
+                error!(target: "threaded-stream",
+                       "mutex poisoned");
+
+                RetryResult::Success(())
+            }
+        }
+    }
+}
+
+impl<Ctx, Inner> PushStreamShared<Ctx> for ThreadedStream<Inner>
+where
+    Inner: PushStreamShared<Ctx>
+{
+    type AbortBatchRetry = Inner::AbortBatchRetry;
+    type CreateBatchError = ThreadedStreamError<Inner::CreateBatchError>;
+    type CreateBatchRetry = Inner::CreateBatchRetry;
+    type SelectError = ThreadedStreamError<Inner::SelectError>;
+    type SelectRetry = Inner::SelectRetry;
+    type Selections = Inner::Selections;
+    type StartBatchError = ThreadedStreamError<Inner::StartBatchError>;
+    type StartBatchRetry = Inner::StartBatchRetry;
+    type StartBatchStreamBatches = Inner::StartBatchStreamBatches;
+
+    #[inline]
+    fn empty_selections_with_capacity(size: usize) -> Self::Selections {
+        Inner::empty_selections_with_capacity(size)
+    }
+
+    #[inline]
+    fn empty_batches_with_capacity(
+        size: usize
+    ) -> Self::StartBatchStreamBatches {
+        Inner::empty_batches_with_capacity(size)
+    }
+
+    fn select<'a, I>(
+        &mut self,
+        ctx: &mut Ctx,
+        selections: &mut Self::Selections,
+        parties: I
+    ) -> Result<RetryResult<(), Self::SelectRetry>, Self::SelectError>
     where
-        I: Iterator<Item = Self::PartyID> {
+        I: Iterator<Item = &'a Self::PartyID>,
+        Self::PartyID: 'a {
         let mut guard = self
             .inner
             .lock()
             .map_err(|_| ThreadedStreamError::MutexPoison)?;
 
         guard
-            .add_parties(ctx, parties, batch)
+            .select(ctx, selections, parties)
             .map_err(|err| ThreadedStreamError::Inner { error: err })
     }
 
-    fn retry_add_parties(
+    fn retry_select(
         &mut self,
         ctx: &mut Ctx,
-        batch: &Self::BatchID,
-        retry: Self::AddPartiesRetry
-    ) -> Result<RetryResult<(), Self::AddPartiesRetry>, Self::AddPartiesError>
-    {
+        selections: &mut Self::Selections,
+        retry: Self::SelectRetry
+    ) -> Result<RetryResult<(), Self::SelectRetry>, Self::SelectError> {
         let mut guard = self
             .inner
             .lock()
             .map_err(|_| ThreadedStreamError::MutexPoison)?;
 
         guard
-            .retry_add_parties(ctx, batch, retry)
+            .retry_select(ctx, selections, retry)
             .map_err(|err| ThreadedStreamError::Inner { error: err })
     }
 
-    fn complete_add_parties(
+    fn complete_select(
         &mut self,
         ctx: &mut Ctx,
-        batch: &Self::BatchID,
-        err: <Self::AddPartiesError as BatchError>::Completable
-    ) -> Result<RetryResult<(), Self::AddPartiesRetry>, Self::AddPartiesError>
-    {
+        selections: &mut Self::Selections,
+        err: <Self::SelectError as BatchError>::Completable
+    ) -> Result<RetryResult<(), Self::SelectRetry>, Self::SelectError> {
         let mut guard = self
             .inner
             .lock()
             .map_err(|_| ThreadedStreamError::MutexPoison)?;
 
         guard
-            .complete_add_parties(ctx, batch, err)
+            .complete_select(ctx, selections, err)
             .map_err(|err| ThreadedStreamError::Inner { error: err })
+    }
+
+    fn create_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        batches: &mut Self::StartBatchStreamBatches,
+        selections: &Self::Selections
+    ) -> Result<
+        RetryResult<Self::BatchID, Self::CreateBatchRetry>,
+        Self::CreateBatchError
+    > {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| ThreadedStreamError::MutexPoison)?;
+
+        guard
+            .create_batch(ctx, batches, selections)
+            .map_err(|err| ThreadedStreamError::Inner { error: err })
+    }
+
+    fn retry_create_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        batches: &mut Self::StartBatchStreamBatches,
+        selections: &Self::Selections,
+        retry: Self::CreateBatchRetry
+    ) -> Result<
+        RetryResult<Self::BatchID, Self::CreateBatchRetry>,
+        Self::CreateBatchError
+    > {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| ThreadedStreamError::MutexPoison)?;
+
+        guard
+            .retry_create_batch(ctx, batches, selections, retry)
+            .map_err(|err| ThreadedStreamError::Inner { error: err })
+    }
+
+    fn complete_create_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        batches: &mut Self::StartBatchStreamBatches,
+        selections: &Self::Selections,
+        err: <Self::CreateBatchError as BatchError>::Completable
+    ) -> Result<
+        RetryResult<Self::BatchID, Self::CreateBatchRetry>,
+        Self::CreateBatchError
+    > {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| ThreadedStreamError::MutexPoison)?;
+
+        guard
+            .complete_create_batch(ctx, batches, selections, err)
+            .map_err(|err| ThreadedStreamError::Inner { error: err })
+    }
+
+    fn start_batch<'a, I>(
+        &mut self,
+        ctx: &mut Ctx,
+        parties: I
+    ) -> Result<
+        RetryResult<Self::BatchID, Self::StartBatchRetry>,
+        Self::StartBatchError
+    >
+    where
+        I: Iterator<Item = &'a Self::PartyID>,
+        Self::PartyID: 'a {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| ThreadedStreamError::MutexPoison)?;
+
+        guard
+            .start_batch(ctx, parties)
+            .map_err(|err| ThreadedStreamError::Inner { error: err })
+    }
+
+    fn retry_start_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        retry: Self::StartBatchRetry
+    ) -> Result<
+        RetryResult<Self::BatchID, Self::StartBatchRetry>,
+        Self::StartBatchError
+    > {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| ThreadedStreamError::MutexPoison)?;
+
+        guard
+            .retry_start_batch(ctx, retry)
+            .map_err(|err| ThreadedStreamError::Inner { error: err })
+    }
+
+    fn complete_start_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        err: <Self::StartBatchError as BatchError>::Completable
+    ) -> Result<
+        RetryResult<Self::BatchID, Self::StartBatchRetry>,
+        Self::StartBatchError
+    > {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| ThreadedStreamError::MutexPoison)?;
+
+        guard
+            .complete_start_batch(ctx, err)
+            .map_err(|err| ThreadedStreamError::Inner { error: err })
+    }
+
+    fn abort_start_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        flags: &mut Self::StreamFlags,
+        err: <Self::StartBatchError as BatchError>::Permanent
+    ) -> RetryResult<(), Self::AbortBatchRetry> {
+        match err {
+            ThreadedStreamError::Inner { error } => match self.inner.lock() {
+                Ok(mut guard) => guard.abort_start_batch(ctx, flags, error),
+                Err(_) => {
+                    error!(target: "threaded-stream",
+                           "mutex poisoned");
+
+                    RetryResult::Success(())
+                }
+            },
+            ThreadedStreamError::MutexPoison => {
+                warn!(target: "threaded-stream",
+                      "could not cancel batch with error: mutex poisoned");
+
+                RetryResult::Success(())
+            }
+        }
+    }
+
+    fn retry_abort_start_batch(
+        &mut self,
+        ctx: &mut Ctx,
+        flags: &mut Self::StreamFlags,
+        retry: Self::AbortBatchRetry
+    ) -> RetryResult<(), Self::AbortBatchRetry> {
+        match self.inner.lock() {
+            Ok(mut guard) => guard.retry_abort_start_batch(ctx, flags, retry),
+            Err(_) => {
+                error!(target: "threaded-stream",
+                       "mutex poisoned");
+
+                RetryResult::Success(())
+            }
+        }
     }
 }
 
@@ -1451,14 +1942,15 @@ where
     type PushError = ThreadedStreamError<Inner::PushError>;
     type PushRetry = Inner::PushRetry;
 
-    fn push<I>(
+    fn push<'a, I>(
         &mut self,
         ctx: &mut Ctx,
         parties: I,
         msg: &T
     ) -> Result<RetryResult<Self::BatchID, Self::PushRetry>, Self::PushError>
     where
-        I: Iterator<Item = Self::PartyID> {
+        I: Iterator<Item = &'a Self::PartyID>,
+        Self::PartyID: 'a {
         let mut guard = self
             .inner
             .lock()
@@ -1557,9 +2049,9 @@ where
     }
 }
 
-impl<T, Ctx, Inner> PushStreamSingle<T, Ctx> for ThreadedStream<Inner>
+impl<T, Ctx, Inner> PushStreamPrivateSingle<T, Ctx> for ThreadedStream<Inner>
 where
-    Inner: PushStreamSingle<T, Ctx>
+    Inner: PushStreamPrivateSingle<T, Ctx>
 {
     type CancelPushError = ThreadedStreamError<Inner::CancelPushError>;
     type CancelPushRetry = Inner::CancelPushRetry;
@@ -1719,79 +2211,6 @@ impl<Inner> ThreadedStream<Inner> {
         ThreadedStream {
             inner: Arc::new(Mutex::new(inner))
         }
-    }
-}
-
-impl<BatchID> Default for NullBatches<BatchID>
-where
-    BatchID: Clone
-{
-    #[inline]
-    fn default() -> Self {
-        NullBatches { batch: PhantomData }
-    }
-}
-
-impl<BatchID> StreamBatches for NullBatches<BatchID>
-where
-    BatchID: Clone
-{
-    type BatchID = BatchID;
-    type StreamID = ();
-
-    #[inline]
-    fn new() -> Self {
-        Self::default()
-    }
-
-    #[inline]
-    fn with_capacity(_size: usize) -> Self {
-        Self::default()
-    }
-
-    #[inline]
-    fn batch(
-        &self,
-        _stream: &Self::StreamID
-    ) -> Option<Self::BatchID> {
-        None
-    }
-
-    #[inline]
-    fn add_batch(
-        &mut self,
-        _stream: Self::StreamID,
-        _batch: Self::BatchID
-    ) {
-    }
-}
-
-impl StreamFlags for () {
-    type StreamID = ();
-
-    #[inline]
-    fn new() -> Self {
-        Self::default()
-    }
-
-    #[inline]
-    fn with_capacity(_size: usize) -> Self {
-        Self::default()
-    }
-
-    #[inline]
-    fn is_set(
-        &self,
-        _stream: &Self::StreamID
-    ) -> bool {
-        false
-    }
-
-    #[inline]
-    fn set(
-        &mut self,
-        _stream: Self::StreamID
-    ) {
     }
 }
 

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -44,6 +44,7 @@ use crate::error::BatchError;
 use crate::error::ErrorReportInfo;
 
 pub mod pull;
+pub mod push;
 
 /// Trait for caches used in stream creation to allow shared streams.
 ///

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -113,7 +113,10 @@ pub trait PullStreamListener<T> {
     /// This call will generally block the calling thread.
     fn listen(
         &mut self
-    ) -> Result<(Self::Addr, Self::Prin, Self::Stream), Self::ListenError>;
+    ) -> Result<
+        RetryResult<(Self::Stream, Self::Addr, Self::Prin)>,
+        Self::ListenError
+    >;
 }
 
 /// Basic interface for a push stream.

--- a/src/stream/pull.rs
+++ b/src/stream/pull.rs
@@ -397,7 +397,8 @@ where
                     // ISSUE #11: handle session-level credentials and
                     // authentication here.
 
-                    let stream = ThreadedStream::new(stream);
+                    let stream =
+                        ThreadedStream::new(self.shutdown.clone(), stream);
 
                     match stream_reporter.report(addr.clone(), prin, stream) {
                         Ok(None) => {

--- a/src/stream/pull.rs
+++ b/src/stream/pull.rs
@@ -601,8 +601,7 @@ where
     /// is a [ShutdownFlag] that will be used to shut down the pull
     /// side.  The `authn` parameter is the authenticator.
     ///
-    /// This will also create a [PullStreamsListenThread] and a
-    /// [PullStreamsReceiver].
+    /// This will also create a [PullStreamsListenThread].
     pub fn with_capacity(
         listener: Listener,
         recv: Recv,

--- a/src/stream/pull.rs
+++ b/src/stream/pull.rs
@@ -26,8 +26,10 @@ use std::hash::Hash;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::thread::sleep;
 use std::thread::spawn;
 use std::thread::JoinHandle;
+use std::time::Instant;
 
 use constellation_auth::authn::AuthNMsgRecv;
 use constellation_auth::authn::AuthNResult;
@@ -35,6 +37,7 @@ use constellation_auth::authn::MsgAuthN;
 use constellation_auth::cred::Credentials;
 use constellation_common::error::ErrorScope;
 use constellation_common::error::ScopedError;
+use constellation_common::retry::RetryResult;
 use constellation_common::shutdown::ShutdownFlag;
 use log::debug;
 use log::error;
@@ -389,13 +392,10 @@ where
                    "listening for connection");
 
             match self.listener.listen() {
-                Ok((addr, prin, stream)) => {
+                Ok(RetryResult::Success((stream, addr, prin))) => {
                     info!(target: "pull-streams-listen-thread",
                           "received new incoming stream from {}",
                           addr);
-
-                    // ISSUE #11: handle session-level credentials and
-                    // authentication here.
 
                     let stream =
                         ThreadedStream::new(self.shutdown.clone(), stream);
@@ -416,6 +416,21 @@ where
                                    "error reporting new stream: {}",
                                    err)
                         }
+                    }
+                }
+                Ok(RetryResult::Retry(until)) => {
+                    let now = Instant::now();
+
+                    if now < until {
+                        let delay = until - now;
+
+                        debug!(
+                            "retrying listen in {}.{:03}s",
+                            delay.as_secs(),
+                            delay.subsec_millis()
+                        );
+
+                        sleep(delay)
                     }
                 }
                 Err(err) => {

--- a/src/stream/push.rs
+++ b/src/stream/push.rs
@@ -1,0 +1,1040 @@
+// Copyright © 2024 The Johns Hopkins Applied Physics Laboratory LLC.
+//
+// This program is free software: you can redistribute it and/or
+// modify it under the terms of the GNU Affero General Public License,
+// version 3, as published by the Free Software Foundation.  If you
+// would like to purchase a commercial license for this software, please
+// contact APL’s Tech Transfer at 240-592-0817 or
+// techtransfer@jhuapl.edu.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <https://www.gnu.org/licenses/>.
+
+use std::thread::spawn;
+use std::thread::JoinHandle;
+use std::time::Instant;
+
+use constellation_common::error::ErrorScope;
+use constellation_common::error::ScopedError;
+use constellation_common::net::SharedMsgs;
+use constellation_common::retry::RetryResult;
+use constellation_common::retry::RetryWhen;
+use constellation_common::shutdown::ShutdownFlag;
+use constellation_common::sync::Notify;
+use log::debug;
+use log::error;
+use log::info;
+use log::trace;
+
+use crate::error::BatchError;
+use crate::stream::PushStreamAdd;
+use crate::stream::PushStreamAddParty;
+use crate::stream::PushStreamParties;
+use crate::stream::PushStreamReportBatchError;
+use crate::stream::PushStreamReportError;
+use crate::stream::PushStreamShared;
+use crate::stream::PushStreamSharedSingle;
+
+/// Backlog entry for push threads.
+///
+/// This records the state of a partially-completed operation.
+enum PushEntry<Msg, Stream, Ctx>
+where
+    Stream: PushStreamReportBatchError<
+            <Stream::FinishBatchError as BatchError>::Permanent,
+            Stream::BatchID
+        > + PushStreamReportError<
+            <Stream::StartBatchError as BatchError>::Permanent
+        > + PushStreamReportBatchError<
+            <Stream::AddError as BatchError>::Permanent,
+            Stream::BatchID
+        > + PushStreamReportBatchError<
+            <Stream::AddPartiesError as BatchError>::Permanent,
+            Stream::BatchID
+        > + PushStreamAdd<Msg, Ctx>
+        + PushStreamAddParty<Ctx>
+        + Send,
+    Msg: Clone + Send {
+    Batch {
+        msgs: Vec<Msg>,
+        parties: Vec<Stream::PartyID>,
+        batches: Stream::StartBatchStreamBatches,
+        retry: Stream::StartBatchRetry
+    },
+    Abort {
+        flags: Stream::StreamFlags,
+        retry: Stream::AbortBatchRetry
+    },
+    Parties {
+        msgs: Vec<Msg>,
+        batch: Stream::BatchID,
+        retry: Stream::AddPartiesRetry
+    },
+    Add {
+        msgs: Vec<Msg>,
+        msg: Msg,
+        flags: Stream::StreamFlags,
+        batch: Stream::BatchID,
+        retry: Stream::AddRetry
+    },
+    Finish {
+        batch: Stream::BatchID,
+        retry: Stream::FinishBatchRetry
+    },
+    Cancel {
+        flags: Stream::StreamFlags,
+        batch: Stream::BatchID,
+        retry: Stream::CancelBatchRetry
+    }
+}
+
+pub struct PushStreamSharedThread<Msg, Msgs, Stream, Ctx>
+where
+    Stream: PushStreamReportBatchError<
+            <Stream::FinishBatchError as BatchError>::Permanent,
+            Stream::BatchID
+        > + PushStreamReportError<
+            <Stream::StartBatchError as BatchError>::Permanent
+        > + PushStreamReportBatchError<
+            <Stream::AddError as BatchError>::Permanent,
+            Stream::BatchID
+        > + PushStreamReportBatchError<
+            <Stream::AddPartiesError as BatchError>::Permanent,
+            Stream::BatchID
+        > + PushStreamSharedSingle<Msg, Ctx>
+        + PushStreamShared
+        + PushStreamParties
+        + Send,
+    Stream::StartBatchStreamBatches: Send,
+    Stream::StartBatchRetry: Send,
+    Stream::AbortBatchRetry: Send,
+    Stream::AddPartiesRetry: Send,
+    Stream::AddRetry: Send,
+    Stream::FinishBatchRetry: Send,
+    Stream::CancelBatchRetry: Send,
+    Stream::StreamFlags: Send,
+    Stream::PartyID: From<usize> + Send,
+    Stream::BatchID: Send,
+    Msgs: SharedMsgs<Stream::PartyID, Msg>,
+    Msg: Clone + Send,
+    Ctx: Send + Sync {
+    ctx: Ctx,
+    /// Buffer for sends in progress.
+    pending: Vec<PushEntry<Msg, Stream, Ctx>>,
+    /// Source of outbound messages.
+    msgs: Msgs,
+    /// `Notify` instance used to indicate that new messages are
+    /// available to be sent.
+    notify: Notify,
+    /// Flag to use to shut the stream down.
+    shutdown: ShutdownFlag,
+    /// Stream to use to send.
+    stream: Stream
+}
+
+impl<Msg, Stream, Ctx> RetryWhen for PushEntry<Msg, Stream, Ctx>
+where
+    Stream: PushStreamAdd<Msg, Ctx>
+        + PushStreamAddParty<Ctx>
+        + PushStreamReportBatchError<
+            <Stream::FinishBatchError as BatchError>::Permanent,
+            Stream::BatchID
+        > + PushStreamReportError<
+            <Stream::StartBatchError as BatchError>::Permanent
+        > + PushStreamReportBatchError<
+            <Stream::AddError as BatchError>::Permanent,
+            Stream::BatchID
+        > + PushStreamReportBatchError<
+            <Stream::AddPartiesError as BatchError>::Permanent,
+            Stream::BatchID
+        > + Send,
+    Msg: Clone + Send
+{
+    fn when(&self) -> Instant {
+        match self {
+            PushEntry::Batch { retry, .. } => retry.when(),
+            PushEntry::Abort { retry, .. } => retry.when(),
+            PushEntry::Parties { retry, .. } => retry.when(),
+            PushEntry::Add { retry, .. } => retry.when(),
+            PushEntry::Finish { retry, .. } => retry.when(),
+            PushEntry::Cancel { retry, .. } => retry.when()
+        }
+    }
+}
+
+impl<Msg, Stream, Ctx> PushEntry<Msg, Stream, Ctx>
+where
+    Stream: 'static
+        + PushStreamReportBatchError<
+            <Stream::FinishBatchError as BatchError>::Permanent,
+            Stream::BatchID
+        >
+        + PushStreamReportError<
+            <Stream::StartBatchError as BatchError>::Permanent
+        >
+        + PushStreamReportBatchError<
+            <Stream::AddError as BatchError>::Permanent,
+            Stream::BatchID
+        >
+        + PushStreamReportBatchError<
+            <Stream::AddPartiesError as BatchError>::Permanent,
+            Stream::BatchID
+        >
+        + PushStreamAddParty<Ctx>
+        + PushStreamAdd<Msg, Ctx>
+        + Send,
+    Stream::PartyID: From<usize>,
+    Msg: 'static + Clone + Send
+{
+    fn complete_cancel_batch(
+        ctx: &mut Ctx,
+        stream: &mut Stream,
+        mut flags: Stream::StreamFlags,
+        batch_id: Stream::BatchID,
+        err: Stream::CancelBatchError
+    ) -> RetryResult<(), Self> {
+        trace!(target: "push-entry",
+               "attempting to recover from error while cancelling message");
+
+        match err.split() {
+            (Some(completable), None) => {
+                match stream.complete_cancel_batch(
+                    ctx,
+                    &mut flags,
+                    &batch_id,
+                    completable
+                ) {
+                    // It succeeded.
+                    Ok(RetryResult::Success(_)) => {
+                        trace!(target: "push-entry",
+                           "successfully completed cancellation");
+
+                        RetryResult::Success(())
+                    }
+                    // We got a retry.
+                    Ok(RetryResult::Retry(retry)) => {
+                        RetryResult::Retry(PushEntry::Cancel {
+                            batch: batch_id,
+                            retry: retry,
+                            flags: flags
+                        })
+                    }
+                    // More errors; recurse again.
+                    Err(err) => Self::complete_cancel_batch(
+                        ctx, stream, flags, batch_id, err
+                    )
+                }
+            }
+            // Unrecoverable errors occurred canceling the batch.
+            (_, Some(permanent)) => {
+                error!(target: "push-entry",
+                       "unrecoverable error canceling batch: {}",
+                       permanent);
+
+                RetryResult::Success(())
+            }
+            (None, None) => {
+                error!(target: "push-entry",
+                       "neither completable nor permanent errors reported");
+
+                RetryResult::Success(())
+            }
+        }
+    }
+
+    fn try_cancel_batch(
+        ctx: &mut Ctx,
+        stream: &mut Stream,
+        batch_id: Stream::BatchID
+    ) -> RetryResult<(), Self> {
+        let mut flags = stream.empty_flags();
+
+        match stream.cancel_batch(ctx, &mut flags, &batch_id) {
+            // It succeeded.
+            Ok(RetryResult::Success(_)) => RetryResult::Success(()),
+            // We got a retry.
+            Ok(RetryResult::Retry(retry)) => {
+                RetryResult::Retry(PushEntry::Cancel {
+                    batch: batch_id,
+                    retry: retry,
+                    flags: flags
+                })
+            }
+            Err(err) => {
+                Self::complete_cancel_batch(ctx, stream, flags, batch_id, err)
+            }
+        }
+    }
+
+    fn complete_finish(
+        ctx: &mut Ctx,
+        stream: &mut Stream,
+        flags: &mut Stream::StreamFlags,
+        batch_id: Stream::BatchID,
+        err: Stream::FinishBatchError
+    ) -> RetryResult<(), Self> {
+        trace!(target: "push-entry",
+               "attempting to recover from error while finishing batch");
+
+        match err.split() {
+            (Some(completable), None) => {
+                match stream.complete_finish_batch(
+                    ctx,
+                    flags,
+                    &batch_id,
+                    completable
+                ) {
+                    // It succeeded.
+                    Ok(RetryResult::Success(())) => {
+                        trace!(target: "push-entry",
+                           "successfully finished batch");
+
+                        RetryResult::Success(())
+                    }
+                    // We got a retry.
+                    Ok(RetryResult::Retry(retry)) => {
+                        RetryResult::Retry(PushEntry::Finish {
+                            batch: batch_id,
+                            retry: retry
+                        })
+                    }
+                    // More errors; recurse again.
+                    Err(err) => {
+                        Self::complete_finish(ctx, stream, flags, batch_id, err)
+                    }
+                }
+            }
+            // Permanent errors always kill the batch.
+            (_, Some(permanent)) => {
+                // Unrecoverable errors occurred canceling the batch.
+                error!(target: "push-entry",
+                       "unrecoverable error finishing batch: {}",
+                       permanent);
+
+                // Report the failure
+                if let Err(err) =
+                    stream.report_error_with_batch(&batch_id, &permanent)
+                {
+                    error!(target: "push-entry",
+                           "failed to report errors to stream: {}",
+                           err);
+                }
+
+                Self::try_cancel_batch(ctx, stream, batch_id)
+            }
+            (None, None) => {
+                error!(target: "push-entry",
+                       "neither completable nor permanent errors reported");
+
+                RetryResult::Success(())
+            }
+        }
+    }
+
+    fn try_finish_batch(
+        ctx: &mut Ctx,
+        stream: &mut Stream,
+        batch_id: Stream::BatchID
+    ) -> RetryResult<(), Self> {
+        let mut flags = stream.empty_flags();
+
+        match stream.finish_batch(ctx, &mut flags, &batch_id) {
+            // It succeeded.
+            Ok(RetryResult::Success(_)) => RetryResult::Success(()),
+            // We got a retry.
+            Ok(RetryResult::Retry(retry)) => {
+                RetryResult::Retry(PushEntry::Finish {
+                    batch: batch_id.clone(),
+                    retry: retry
+                })
+            }
+            Err(err) => Self::complete_finish(
+                ctx,
+                stream,
+                &mut flags,
+                batch_id.clone(),
+                err
+            )
+        }
+    }
+
+    fn complete_add(
+        ctx: &mut Ctx,
+        stream: &mut Stream,
+        mut flags: Stream::StreamFlags,
+        msgs: Vec<Msg>,
+        msg: Msg,
+        batch_id: Stream::BatchID,
+        err: Stream::AddError
+    ) -> RetryResult<(), Self> {
+        trace!(target: "push-entry",
+               "attempting to recover from error while adding message");
+
+        match err.split() {
+            (Some(completable), None) => {
+                match stream.complete_add(
+                    ctx,
+                    &mut flags,
+                    &msg,
+                    &batch_id,
+                    completable
+                ) {
+                    // It succeeded.
+                    Ok(RetryResult::Success(())) => {
+                        trace!(target: "push-entry",
+                           "successfully added message");
+
+                        Self::try_add(ctx, stream, msgs, batch_id)
+                    }
+                    // We got a retry.
+                    Ok(RetryResult::Retry(retry)) => {
+                        RetryResult::Retry(PushEntry::Add {
+                            msgs: msgs,
+                            msg: msg,
+                            flags: flags,
+                            batch: batch_id,
+                            retry: retry
+                        })
+                    }
+                    // More errors; recurse again.
+                    Err(err) => Self::complete_add(
+                        ctx, stream, flags, msgs, msg, batch_id, err
+                    )
+                }
+            }
+            // Permanent errors always kill the batch.
+            (_, Some(permanent)) => {
+                // Unrecoverable errors occurred adding the message.
+                error!(target: "push-entry",
+                       "unrecoverable error adding message: {}",
+                       permanent);
+
+                // Report the failure
+                if let Err(err) =
+                    stream.report_error_with_batch(&batch_id, &permanent)
+                {
+                    error!(target: "push-entry",
+                           "failed to report errors to stream: {}",
+                           err);
+                }
+
+                Self::try_cancel_batch(ctx, stream, batch_id)
+            }
+            (None, None) => {
+                error!(target: "push-entry",
+                       "neither completable nor permanent errors reported");
+
+                RetryResult::Success(())
+            }
+        }
+    }
+
+    fn try_add_msg(
+        ctx: &mut Ctx,
+        stream: &mut Stream,
+        mut flags: Stream::StreamFlags,
+        msgs: Vec<Msg>,
+        msg: Msg,
+        batch_id: Stream::BatchID
+    ) -> RetryResult<(), Self> {
+        match stream.add(ctx, &mut flags, &msg, &batch_id) {
+            // It succeeded.
+            Ok(RetryResult::Success(_)) => {
+                Self::try_add(ctx, stream, msgs, batch_id)
+            }
+            // We got a retry.
+            Ok(RetryResult::Retry(retry)) => {
+                RetryResult::Retry(PushEntry::Add {
+                    msgs: msgs,
+                    msg: msg,
+                    flags: flags,
+                    batch: batch_id,
+                    retry: retry
+                })
+            }
+            Err(err) => {
+                Self::complete_add(ctx, stream, flags, msgs, msg, batch_id, err)
+            }
+        }
+    }
+
+    fn try_add(
+        ctx: &mut Ctx,
+        stream: &mut Stream,
+        mut msgs: Vec<Msg>,
+        batch_id: Stream::BatchID
+    ) -> RetryResult<(), Self> {
+        match msgs.pop() {
+            Some(msg) => {
+                let flags = stream.empty_flags();
+
+                Self::try_add_msg(ctx, stream, flags, msgs, msg, batch_id)
+            }
+            None => Self::try_finish_batch(ctx, stream, batch_id)
+        }
+    }
+
+    fn complete_add_parties(
+        ctx: &mut Ctx,
+        stream: &mut Stream,
+        msgs: Vec<Msg>,
+        batch_id: Stream::BatchID,
+        err: Stream::AddPartiesError
+    ) -> RetryResult<(), Self> {
+        trace!(target: "push-entry",
+               "attempting to recover from error while adding parties");
+
+        match err.split() {
+            (Some(completable), None) => {
+                match stream.complete_add_parties(ctx, &batch_id, completable) {
+                    // It succeeded.
+                    Ok(RetryResult::Success(())) => {
+                        trace!(target: "push-entry",
+                           "successfully added parties");
+
+                        Self::try_add(ctx, stream, msgs, batch_id)
+                    }
+                    // We got a retry.
+                    Ok(RetryResult::Retry(retry)) => {
+                        RetryResult::Retry(PushEntry::Parties {
+                            msgs: msgs,
+                            batch: batch_id,
+                            retry: retry
+                        })
+                    }
+                    // More errors; recurse again.
+                    Err(err) => Self::complete_add_parties(
+                        ctx, stream, msgs, batch_id, err
+                    )
+                }
+            }
+            // Permanent errors always kill the batch.
+            (_, Some(permanent)) => {
+                // Unrecoverable errors occurred adding the message.
+                error!(target: "push-entry",
+                       "unrecoverable error adding parties: {}",
+                       permanent);
+
+                // Report the failure
+                if let Err(err) =
+                    stream.report_error_with_batch(&batch_id, &permanent)
+                {
+                    error!(target: "push-entry",
+                           "failed to report errors to stream: {}",
+                           err);
+                }
+
+                Self::try_cancel_batch(ctx, stream, batch_id)
+            }
+            (None, None) => {
+                error!(target: "push-entry",
+                       "neither completable nor permanent errors reported");
+
+                RetryResult::Success(())
+            }
+        }
+    }
+
+    fn try_add_parties(
+        ctx: &mut Ctx,
+        stream: &mut Stream,
+        parties: Vec<Stream::PartyID>,
+        msgs: Vec<Msg>,
+        batch_id: Stream::BatchID
+    ) -> RetryResult<(), Self> {
+        match stream.add_parties(ctx, parties.into_iter(), &batch_id) {
+            // It succeeded.
+            Ok(RetryResult::Success(_)) => {
+                Self::try_add(ctx, stream, msgs, batch_id)
+            }
+            // We got a retry.
+            Ok(RetryResult::Retry(retry)) => {
+                RetryResult::Retry(PushEntry::Parties {
+                    msgs: msgs,
+                    batch: batch_id,
+                    retry: retry
+                })
+            }
+            Err(err) => {
+                Self::complete_add_parties(ctx, stream, msgs, batch_id, err)
+            }
+        }
+    }
+
+    fn complete_start_batch(
+        ctx: &mut Ctx,
+        stream: &mut Stream,
+        parties: Vec<Stream::PartyID>,
+        msgs: Vec<Msg>,
+        mut batches: Stream::StartBatchStreamBatches,
+        err: Stream::StartBatchError
+    ) -> RetryResult<(), Self> {
+        trace!(target: "push-entry",
+               "attempting to recover from error while creating batch");
+
+        match err.split() {
+            (Some(completable), None) => {
+                match stream.complete_start_batch(
+                    ctx,
+                    &mut batches,
+                    completable
+                ) {
+                    // It succeeded.
+                    Ok(RetryResult::Success(batch_id)) => {
+                        trace!(target: "push-entry",
+                           "successfully created batch");
+
+                        Self::try_add_parties(
+                            ctx, stream, parties, msgs, batch_id
+                        )
+                    }
+                    // We got a retry.
+                    Ok(RetryResult::Retry(retry)) => {
+                        RetryResult::Retry(PushEntry::Batch {
+                            msgs: msgs,
+                            batches: batches,
+                            parties: parties,
+                            retry: retry
+                        })
+                    }
+                    // More errors; recurse again.
+                    Err(err) => Self::complete_start_batch(
+                        ctx, stream, parties, msgs, batches, err
+                    )
+                }
+            }
+            // Permanent errors always kill the batch.
+            (_, Some(permanent)) => {
+                // Unrecoverable errors occurred adding the message.
+                error!(target: "push-entry",
+                       "unrecoverable error adding parties: {}",
+                       permanent);
+
+                // Report the failure
+                if let Err(err) = stream.report_error(&permanent) {
+                    error!(target: "push-entry",
+                           "failed to report errors to stream: {}",
+                           err);
+                }
+
+                let mut flags = stream.empty_flags();
+
+                stream
+                    .abort_start_batch(ctx, &mut flags, permanent)
+                    .map_retry(|retry| PushEntry::Abort {
+                        flags: flags,
+                        retry: retry
+                    })
+            }
+            (None, None) => {
+                error!(target: "push-entry",
+                       "neither completable nor permanent errors reported");
+
+                RetryResult::Success(())
+            }
+        }
+    }
+
+    fn try_start_batch(
+        ctx: &mut Ctx,
+        stream: &mut Stream,
+        parties: Vec<Stream::PartyID>,
+        msgs: Vec<Msg>
+    ) -> RetryResult<(), Self> {
+        let mut batches = stream.empty_batches();
+
+        match stream.start_batch(ctx, &mut batches) {
+            // It succeeded.
+            Ok(RetryResult::Success(batch_id)) => {
+                Self::try_add_parties(ctx, stream, parties, msgs, batch_id)
+            }
+            // We got a retry.
+            Ok(RetryResult::Retry(retry)) => {
+                RetryResult::Retry(PushEntry::Batch {
+                    msgs: msgs,
+                    batches: batches,
+                    parties: parties,
+                    retry: retry
+                })
+            }
+            Err(err) => Self::complete_start_batch(
+                ctx, stream, parties, msgs, batches, err
+            )
+        }
+    }
+
+    fn exec(
+        self,
+        ctx: &mut Ctx,
+        stream: &mut Stream
+    ) -> RetryResult<(), Self> {
+        match self {
+            PushEntry::Batch {
+                msgs,
+                parties,
+                mut batches,
+                retry
+            } => match stream.retry_start_batch(ctx, &mut batches, retry) {
+                // It succeeded.
+                Ok(RetryResult::Success(batch_id)) => {
+                    Self::try_add_parties(ctx, stream, parties, msgs, batch_id)
+                }
+                // We got a retry.
+                Ok(RetryResult::Retry(retry)) => {
+                    RetryResult::Retry(PushEntry::Batch {
+                        msgs: msgs,
+                        batches: batches,
+                        parties: parties,
+                        retry: retry
+                    })
+                }
+                Err(err) => Self::complete_start_batch(
+                    ctx, stream, parties, msgs, batches, err
+                )
+            },
+            PushEntry::Abort { mut flags, retry } => stream
+                .retry_abort_start_batch(ctx, &mut flags, retry)
+                .map_retry(|retry| PushEntry::Abort {
+                    flags: flags,
+                    retry: retry
+                }),
+            PushEntry::Parties { msgs, batch, retry } => {
+                match stream.retry_add_parties(ctx, &batch, retry) {
+                    // It succeeded.
+                    Ok(RetryResult::Success(_)) => {
+                        Self::try_add(ctx, stream, msgs, batch)
+                    }
+                    // We got a retry.
+                    Ok(RetryResult::Retry(retry)) => {
+                        RetryResult::Retry(PushEntry::Parties {
+                            msgs: msgs,
+                            batch: batch,
+                            retry: retry
+                        })
+                    }
+                    Err(err) => Self::complete_add_parties(
+                        ctx, stream, msgs, batch, err
+                    )
+                }
+            }
+            PushEntry::Add {
+                msgs,
+                msg,
+                batch,
+                mut flags,
+                retry
+            } => match stream.retry_add(ctx, &mut flags, &msg, &batch, retry) {
+                // It succeeded.
+                Ok(RetryResult::Success(_)) => {
+                    Self::try_add(ctx, stream, msgs, batch)
+                }
+                // We got a retry.
+                Ok(RetryResult::Retry(retry)) => {
+                    RetryResult::Retry(PushEntry::Add {
+                        msgs: msgs,
+                        msg: msg,
+                        flags: flags,
+                        batch: batch,
+                        retry: retry
+                    })
+                }
+                Err(err) => Self::complete_add(
+                    ctx, stream, flags, msgs, msg, batch, err
+                )
+            },
+            PushEntry::Finish { batch, retry } => {
+                let mut flags = stream.empty_flags();
+
+                match stream.retry_finish_batch(ctx, &mut flags, &batch, retry)
+                {
+                    // It succeeded.
+                    Ok(RetryResult::Success(_)) => RetryResult::Success(()),
+                    // We got a retry.
+                    Ok(RetryResult::Retry(retry)) => {
+                        RetryResult::Retry(PushEntry::Finish {
+                            batch: batch,
+                            retry: retry
+                        })
+                    }
+                    Err(err) => Self::complete_finish(
+                        ctx, stream, &mut flags, batch, err
+                    )
+                }
+            }
+            PushEntry::Cancel {
+                batch,
+                retry,
+                mut flags
+            } => match stream.retry_cancel_batch(ctx, &mut flags, &batch, retry)
+            {
+                // It succeeded.
+                Ok(RetryResult::Success(_)) => RetryResult::Success(()),
+                // We got a retry.
+                Ok(RetryResult::Retry(retry)) => {
+                    RetryResult::Retry(PushEntry::Cancel {
+                        batch: batch,
+                        retry: retry,
+                        flags: flags
+                    })
+                }
+                Err(err) => {
+                    Self::complete_cancel_batch(ctx, stream, flags, batch, err)
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn from_try_send(
+        ctx: &mut Ctx,
+        stream: &mut Stream,
+        parties: Vec<Stream::PartyID>,
+        msgs: Vec<Msg>
+    ) -> RetryResult<(), Self> {
+        Self::try_start_batch(ctx, stream, parties, msgs)
+    }
+}
+
+impl<Msg, Msgs, Stream, Ctx> PushStreamSharedThread<Msg, Msgs, Stream, Ctx>
+where
+    Stream: 'static
+        + PushStreamReportBatchError<
+            <Stream::FinishBatchError as BatchError>::Permanent,
+            Stream::BatchID
+        >
+        + PushStreamReportError<
+            <Stream::StartBatchError as BatchError>::Permanent
+        >
+        + PushStreamReportBatchError<
+            <Stream::AddError as BatchError>::Permanent,
+            Stream::BatchID
+        >
+        + PushStreamReportBatchError<
+            <Stream::AddPartiesError as BatchError>::Permanent,
+            Stream::BatchID
+        >
+        + PushStreamSharedSingle<Msg, Ctx>
+        + PushStreamShared
+        + PushStreamParties
+        + Send,
+    Stream::StartBatchStreamBatches: Send,
+    Stream::StartBatchRetry: Send,
+    Stream::AbortBatchRetry: Send,
+    Stream::AddPartiesRetry: Send,
+    Stream::AddRetry: Send,
+    Stream::FinishBatchRetry: Send,
+    Stream::CancelBatchRetry: Send,
+    Stream::StreamFlags: Send,
+    Stream::PartyID: From<usize> + Send,
+    Stream::BatchID: Send,
+    Msgs: 'static + SharedMsgs<Stream::PartyID, Msg> + Send,
+    Msg: 'static + Clone + Send,
+    Ctx: 'static + Send + Sync
+{
+    #[inline]
+    pub fn create(
+        ctx: Ctx,
+        msgs: Msgs,
+        notify: Notify,
+        stream: Stream,
+        shutdown: ShutdownFlag
+    ) -> Self {
+        PushStreamSharedThread {
+            pending: Vec::new(),
+            msgs: msgs,
+            notify: notify,
+            shutdown: shutdown,
+            stream: stream,
+            ctx: ctx
+        }
+    }
+
+    #[inline]
+    pub fn with_capacity(
+        ctx: Ctx,
+        msgs: Msgs,
+        notify: Notify,
+        stream: Stream,
+        shutdown: ShutdownFlag,
+        size: usize
+    ) -> Self {
+        PushStreamSharedThread {
+            pending: Vec::with_capacity(size),
+            msgs: msgs,
+            notify: notify,
+            shutdown: shutdown,
+            stream: stream,
+            ctx: ctx
+        }
+    }
+
+    /// Get the `Notify` used to signal availability of new messages
+    /// to this thread.
+    #[inline]
+    pub fn notify(&self) -> Notify {
+        self.notify.clone()
+    }
+
+    fn update_from_outbound(
+        &mut self
+    ) -> Result<Option<Instant>, Msgs::MsgsError> {
+        debug!(target: "push-stream-shared-thread",
+               "fetching new outbound messages");
+
+        let (groups, next) = self.msgs.msgs()?;
+
+        if let Some(groups) = groups {
+            // Go through each group and try sending it
+            for (parties, msgs) in groups {
+                if let RetryResult::Retry(retry) = PushEntry::from_try_send(
+                    &mut self.ctx,
+                    &mut self.stream,
+                    parties,
+                    msgs
+                ) {
+                    // We got a retry somewhere along the process, store it.
+                    self.pending.push(retry)
+                }
+            }
+        }
+
+        Ok(next)
+    }
+
+    fn retry_pending(
+        &mut self,
+        now: Instant
+    ) -> Option<Instant> {
+        debug!(target: "push-stream-shared-thread",
+               "retrying pending operations");
+
+        let mut curr = Vec::with_capacity(self.pending.len());
+
+        // First, sort the array by times, but reverse the order so we
+        // can pop the earliest.
+        self.pending
+            .sort_unstable_by_key(|b| std::cmp::Reverse(b.when()));
+
+        while self.pending.last().map_or(false, |ent| ent.when() <= now) {
+            match self.pending.pop() {
+                Some(ent) => {
+                    curr.push(ent);
+                }
+                None => {
+                    error!(target: "push-stream-shared-thread",
+                           "pop should not be empty");
+                }
+            }
+        }
+
+        // The last entry should now be the first time past the present.
+        let out = self.pending.last().map(|ent| ent.when());
+
+        // Try running all the entries we collected.
+        for ent in curr.into_iter() {
+            if let RetryResult::Retry(retry) =
+                ent.exec(&mut self.ctx, &mut self.stream)
+            {
+                // We got a retry somewhere along the process, store it.
+                self.pending.push(retry)
+            }
+        }
+
+        out
+    }
+
+    fn run(mut self) {
+        let mut next_outbound = Some(Instant::now());
+        let mut next_pending = None;
+        let mut valid = true;
+
+        info!(target: "push-stream-shared-thread",
+              "consensus component send thread starting");
+
+        while valid && self.shutdown.is_live() {
+            let now = Instant::now();
+
+            if let Some(when) = next_outbound &&
+                when <= now
+            {
+                match self.update_from_outbound() {
+                    Ok(next) => next_outbound = next,
+                    Err(err) => {
+                        error!(target: "push-stream-shared-thread",
+                               "error obtaining messages: {}",
+                               err);
+
+                        if err.scope() >= ErrorScope::Shutdown {
+                            valid = false
+                        }
+                    }
+                }
+            }
+
+            if let Some(next) = next_pending &&
+                next <= now
+            {
+                next_pending = self.retry_pending(now)
+            }
+
+            match next_pending.map_or(next_outbound, |next| {
+                next_outbound.map(|when| when.max(next))
+            }) {
+                Some(when) => {
+                    let now = Instant::now();
+
+                    if now < when {
+                        let duration = when - now;
+
+                        trace!(target: "push-stream-shared-thread",
+                               "next activity at {}.{:03}",
+                               duration.as_secs(), duration.subsec_millis());
+
+                        match self.notify.wait_timeout(duration) {
+                            Ok(notify) => {
+                                if notify {
+                                    next_outbound = Some(now)
+                                }
+                            }
+                            Err(err) => {
+                                error!(target: "push-stream-shared-thread",
+                                       "error waiting for notification: {}",
+                                       err);
+
+                                valid = false
+                            }
+                        }
+                    }
+                }
+                None => {
+                    trace!(target: "push-stream-shared-thread",
+                           "waiting for notification indefinitely");
+
+                    match self.notify.wait() {
+                        Ok(_) => next_outbound = Some(now),
+                        Err(err) => {
+                            error!(target: "push-stream-shared-thread",
+                                   "error waiting for notification: {}",
+                                   err);
+
+                            valid = false
+                        }
+                    }
+                }
+            }
+        }
+
+        debug!(target: "push-stream-shared-thread",
+               "consensus component send thread exiting");
+    }
+
+    pub fn start(self) -> JoinHandle<()> {
+        spawn(move || self.run())
+    }
+}


### PR DESCRIPTION
Multiple changes to resolve technical debt and other issues:
- Eliminate `PushStreamAddParties` trait and refactor push stream trait hierarchy
- Pull in `PushStreamSendThread` from consensus component
- Fixes to properly shut down threads
- Refactoring of pull side to eliminate one whole layer of listen threads

Addresses #1, #7, #11, and #13